### PR TITLE
Slack var

### DIFF
--- a/.github/workflows/securesdlc-umbrella.yml
+++ b/.github/workflows/securesdlc-umbrella.yml
@@ -9,6 +9,8 @@ on:
         required: true
       SEMGREP_APP_TOKEN:
         required: true
+      SDLC_SLACK_NOTIFICATIONS:
+        required: false        
   pull_request: {}
   # pull_request_target: {} # Gives workflows excessive permissions. Not wanted.
 

--- a/.github/workflows/securesdlc-umbrella.yml
+++ b/.github/workflows/securesdlc-umbrella.yml
@@ -21,6 +21,7 @@ jobs:
     secrets:
       SEMGREP_APP_URL: ${{ secrets.SEMGREP_APP_URL }}
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      SDLC_SLACK_NOTIFICATIONS: ${{ secrets.SDLC_SLACK_NOTIFICATIONS }}      
 
   securesdlc-sca:
     if: ${{ github.actor != 'dependabot[bot]' }}
@@ -28,7 +29,10 @@ jobs:
     secrets:
       SEMGREP_APP_URL: ${{ secrets.SEMGREP_APP_URL }}
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      SDLC_SLACK_NOTIFICATIONS: ${{ secrets.SDLC_SLACK_NOTIFICATIONS }}
 
   securesdlc-zizmor:
     if: ${{ github.actor != 'dependabot[bot]' }}
     uses: nautilus-wraith/securesdlc-zizmor/.github/workflows/securesdlc-zizmor.yml@main
+    secrets:
+      SDLC_SLACK_NOTIFICATIONS: ${{ secrets.SDLC_SLACK_NOTIFICATIONS }}

--- a/.github/workflows/securesdlc-umbrella.yml
+++ b/.github/workflows/securesdlc-umbrella.yml
@@ -10,7 +10,7 @@ on:
       SEMGREP_APP_TOKEN:
         required: true
       SDLC_SLACK_NOTIFICATIONS:
-        required: false        
+        required: true        
   pull_request: {}
   # pull_request_target: {} # Gives workflows excessive permissions. Not wanted.
 

--- a/.github/workflows/securesdlc-umbrella.yml
+++ b/.github/workflows/securesdlc-umbrella.yml
@@ -33,6 +33,6 @@ jobs:
 
   securesdlc-zizmor:
     if: ${{ github.actor != 'dependabot[bot]' }}
-    uses: nautilus-wraith/securesdlc-zizmor/.github/workflows/securesdlc-zizmor.yml@main
+    uses: nautilus-wraith/securesdlc-zizmor/.github/workflows/securesdlc-zizmor.yml@release-stable
     secrets:
       SDLC_SLACK_NOTIFICATIONS: ${{ secrets.SDLC_SLACK_NOTIFICATIONS }}


### PR DESCRIPTION
Umbrella needs certain variable from the caller and needs to pass them downstream to called workflows (SAST, SCA, ZIZMOR)