### PR TITLE
Add Nautilus SecureSDLC workflow

### DIFF
--- a/.github/workflows/securesdlc.yml
+++ b/.github/workflows/securesdlc.yml
@@ -1,0 +1,20 @@
+name: Nautilus SecureSDLC Reusable
+run-name: "[Nautilus SecureSDLC Reusable] Ref:${{ github.ref_name }} Event:${{ github.event_name }}"
+
+on:
+  workflow_dispatch: {}
+  workflow_call: {}
+  push:
+    branches: [ main ]
+
+jobs:
+  securesdlc-umbrella:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status  
+    uses: nautilus-wraith/securesdlc-umbrella/.github/workflows/securesdlc-umbrella.yml@release-stable
+    secrets:
+      SEMGREP_APP_URL: ${{ secrets.SEMGREP_APP_URL }}
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      SDLC_SLACK_NOTIFICATIONS: ${{ secrets.SDLC_SLACK_NOTIFICATIONS }}


### PR DESCRIPTION
This PR adds the Nautilus SecureSDLC workflow to enable automated security scanning.

## Changes
- adds `.github/workflows/securesdlc.yml`
- Enables security scanning on push events
- Supports workflow dispatch for manual runs

## Requirements
This workflow requires the following secrets to be configured in the repository:
- `SEMGREP_APP_URL`: The URL of your Semgrep App instance
- `SEMGREP_APP_TOKEN`: The API token for Semgrep App

## Testing
The workflow will run automatically on:
- Push events to the default branch
- Manual workflow dispatch
- When called by other workflows